### PR TITLE
Don't automatically use source directory when selecting no fields

### DIFF
--- a/dicomsorter.py
+++ b/dicomsorter.py
@@ -91,9 +91,12 @@ class Dicom():
 
     def create_default_overrides(self):
         # Specify which field-types to override
-        self.default_overrides = {'ImageType': self._get_image_type,
-                                  'FileExtension': self._get_file_extension,
-                                  'SeriesDescription': self._get_series_description}
+        self.default_overrides = {
+            'ImageType': self._get_image_type,
+            'FileExtension': self._get_file_extension,
+            'SeriesDescription': self._get_series_description
+        }
+
         self.overrides = dict(self.default_overrides)
 
     def _get_file_extension(self):
@@ -134,10 +137,12 @@ class Dicom():
         Determines the human-readable type of the image
         """
 
-        types = {'Phase': set(['P', ]),
-                 '3DRecon': set(['CSA 3D EDITOR', ]),
-                 'Phoenix': set(['CSA REPORT', ]),
-                 'Mag': set(['FFE', 'M'])}
+        types = {
+            'Phase': set(['P', ]),
+            '3DRecon': set(['CSA 3D EDITOR', ]),
+            'Phoenix': set(['CSA REPORT', ]),
+            'Mag': set(['FFE', 'M'])
+        }
 
         try:
             imType = set(self.dicom.ImageType)
@@ -388,7 +393,7 @@ class DicomSorter():
 
     def GetFolderFormat(self):
         # Check to see if we are using the origin directory structure
-        if not self.folders or len(self.folders) == 0:
+        if self.folders is None:
             return None
 
         # Make a local copy

--- a/gui/widgets.py
+++ b/gui/widgets.py
@@ -472,8 +472,7 @@ class PathEditCtrl(wx.Panel):
 class SeriesRemoveWarningDlg(wx.Dialog):
 
     def __init__(self, parent, id=-1, size=(300, 200), config=None):
-        wx.Dialog.__init__(
-            self, parent, id, 'Remove Series Description?', size=size)
+        wx.Dialog.__init__(self, parent, id, 'Remove Series Description?', size=size)
 
         vbox = wx.BoxSizer(wx.VERTICAL)
 
@@ -484,10 +483,8 @@ class SeriesRemoveWarningDlg(wx.Dialog):
 
         txt = wx.StaticText(self, -1, inputText, style=wx.ALIGN_CENTER)
 
-        change = wx.Button(
-            self, -1, 'Yes. Use original Filenames', size=(-1, 20))
-        accept = wx.Button(
-            self, -1, 'Yes. Use Custom Filenames', size=(-1, 20))
+        change = wx.Button(self, -1, 'Yes. Use original Filenames', size=(-1, 20))
+        accept = wx.Button(self, -1, 'Yes. Use Custom Filenames', size=(-1, 20))
         cancel = wx.Button(self, -1, 'Cancel', size=(-1, 20))
 
         change.Bind(wx.EVT_BUTTON, self.OnChange)
@@ -709,8 +706,7 @@ class FieldSelector(wx.Panel):
                 # change to original filenames
                 cfg = self.GetParent().config
                 cfg['FilenameFormat']['Selection'] = 1
-                self.GetParent(
-                ).prefDlg.pages['FilenameFormat'].UpdateFromConfig(cfg)
+                self.GetParent().prefDlg.pages['FilenameFormat'].UpdateFromConfig(cfg)
 
         self.selected.Delete(index)
 


### PR DESCRIPTION
Fixes #33 

Previously, we were treating no fields selected as "use the original directory" but really it should mean that we don't use *any* directory hierarchy and instead use the selected directory as the base. This is a slight change in behavior but I think it makes more sense.